### PR TITLE
Search doc updates

### DIFF
--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -8,6 +8,7 @@
 
     <ul>
       <li>Create and limit a basic search using the <code>q</code> parameter</li>
+      <li>Sort search results</li>
       <li>Search using required and excluded terms</li>
       <li>Use a quoted search to match exact terms and multiple words</li>
       <li>Search on custom fields</li>
@@ -187,6 +188,17 @@
     </ul>
 
     <aside class="bcls-aside bcls-aside--information">The fields that use a string value perform a text search against that field.</aside>
+  </section>
+
+  <!-- Sorting results -->
+  <section class="bcls-section">
+    <h2 id="Sorting_of_search_results">Sorting of search results</h2>
+
+    <p>For search queries that return a large number of results, the sorting of the results is based on a complex relevance algorithm.</p>
+
+    <p>For example, let's say you search on the terms <code>coastal,city</code> and there are 120 videos in your account that have those terms somewhere in the video metadata ( <code>name</code>, <code>description</code>, <code>tags</code>, and so
+      forth) and that also match the sorting criteria for the results (for example, they all have the same <code>schedule_starts_at</code> date/time). How high in the results a video appears is determined by the frequency that one or both terms
+      appear in the metadata, with greater weight given to the term that appears most frequently in your video library as a whole.</p>
   </section>
 
   <!-- Required/Excluded Search -->
@@ -645,17 +657,6 @@ q=my_field:"foo"</code></pre>
       <li><code>q=%2Bis_clip:false</code> - returns only non-clips</li>
       <li><code>q=%2Bclip_source_video_id: <span class="bcls-input">video_id</span></code> - returns clips generated from the specified video</li>
     </ul>
-  </section>
-
-  <!-- Sorting results -->
-  <section class="bcls-section">
-    <h2 id="Sorting_of_search_results">Sorting of search results</h2>
-
-    <p>For search queries that return a large number of results, the sorting of the results is based on a complex relevance algorithm.</p>
-
-    <p>For example, let's say you search on the terms <code>coastal,city</code> and there are 120 videos in your account that have those terms somewhere in the video metadata ( <code>name</code>, <code>description</code>, <code>tags</code>, and so
-      forth) and that also match the sorting criteria for the results (for example, they all have the same <code>schedule_starts_at</code> date/time). How high in the results a video appears is determined by the frequency that one or both terms
-      appear in the metadata, with greater weight given to the term that appears most frequently in your video library as a whole.</p>
   </section>
 
   <!-- Ignored Words -->

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -249,7 +249,7 @@
 
     <p>Example: This request returns videos which must have a value of <code>bar</code> in the <code>tag</code> field and may have a <code>name</code> containing value <code>foo</code></p>
 
-    <pre class="line-numbers"><code class="language-http">.../videos?q=name:foo%2Btags:bar&amp;sort=updated_at</code></pre>
+    <pre class="line-numbers"><code class="language-http">.../videos?q=name:foo%20%2Btags:bar&amp;sort=updated_at</code></pre>
 
     <p>Example: This request returns the same videos as above, but additionally sorts those results by the field <code>updated_at</code> and then limits the results to just 10 videos.
 

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -1,4 +1,6 @@
 <article class="bcls-article">
+
+  <!-- Intro -->
   <section class="bcls-section">
     <h2 id="Introduction">Introduction</h2>
 
@@ -16,6 +18,7 @@
     <aside class="bcls-aside bcls-aside--information">Note that this topic covers video search - also see <a href="/node/18010">Playlist Search</a>.</aside>
   </section>
 
+  <!-- API Usage -->
   <section class="bcls-section">
     <h2 id="API_usage">API usage</h2>
 
@@ -56,118 +59,13 @@
     <p>For API request/response details, see the <strong>Get Videos</strong> section of the <a href="http://docs.brightcove.com/playback-api/v1/doc/index.html">Playback API Reference</a>.</p>
   </section>
 
-  <section class="bcls-section">
-    <h2 id="Sorting_of_search_results">Sorting of search results</h2>
-
-    <p>For search queries that return a large number of results, the sorting of the results is based on a complex relevance algorithm.</p>
-
-    <p>For example, let's say you search on the terms <code>coastal,city</code> and there are 120 videos in your account that have those terms somewhere in the video metadata ( <code>name</code>, <code>description</code>, <code>tags</code>, and so
-      forth) and that also match the sorting criteria for the results (for example, they all have the same <code>schedule_starts_at</code> date/time). How high in the results a video appears is determined by the frequency that one or both terms
-      appear in the metadata, with greater weight given to the term that appears most frequently in your video library as a whole.</p>
-  </section>
-
-  <section class="bcls-section">
-    <h2 id="url_encoding">Spaces/Special Characters</h2>
-
-    <p>The CMS API generally handles special characters in search strings, with a couple of exceptions:</p>
-
-    <ul>
-      <li>Spaces are not allowed, and can be replaced either with <code>+</code> signs or <code>%20</code>
-
-        <p>For example, to search for "my favorite video" in the name:</p>
-
-        <p><code>q=name:"my+favorite+video"</code></p>
-
-        <p>or</p>
-
-        <p><code>q=name:"my%20favorite%20video"</code></p>
-
-        <aside class="bcls-aside bcls-aside--information">Note that the quotation marks ensure that returned videos have all the terms. Without them, videos having any of the three terms would be returned. More on that below.</aside>
-      </li>
-      <li>Since <code>+</code> signs are interpreted as word separators, to search for a literal <code>+</code> sign or to use the <code>+</code> to indicate that the returned videos <strong>must</strong> include a term, you must encode the <code>+</code> as <code>%2B</code>:
-        <p><code>q=name:two%2Btwo</code></p>
-
-        <p><code>q=%2Bname:heron</code></p>
-      </li>
-      <li>Some agents may not handle literal quotation marks correctly, so it is safer to encode <code>"foo"</code> as <code>%22foo%22</code></li>
-    </ul>
-
-    <aside class="bcls-aside bcls-aside--information">Notes:
-      <p>For multi-word tags or strings, enclose the tag/string in URI-encoded quotation marks ( <code>%22</code>), and URI-encode the spaces <code>(%20)</code>:</p>
-
-      <table class="bcls-table">
-        <caption class="bcls-caption--table">Multi-Word Tag Example</caption>
-        <thead class="bcls-table__head">
-          <tr>
-            <th>Unencoded Search String</th>
-            <th>Encoded Search String</th>
-          </tr>
-        </thead>
-        <tbody class="bcls-table__body">
-          <tr>
-            <td><code>q=tags:"multi word tag"</code></td>
-            <td><code>q=tags:%22multi+word+tag%22</code></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>The quotation marks ensure that videos returned will match ALL of the terms, but NOT necessarily the exact terms. <a href="#Stemming">Stemming</a> still applies - for example, a search on <code>"new house"</code> will also return videos with a <code>name</code> or <code>description</code> like <code>news about housing</code>.</p>
-    </aside>
-
-    <p>For one-off requests, you can use Brightcove Learning's <a href="/node/18290">string encoder</a> to encode your search strings. For apps, you'll need to find a URI encoding function in the language you are using.</p>
-
-    <aside class="bcls-aside bcls-aside--warning">Asterisks ( <strong>*</strong>) are treated as ordinary special characters, <strong>not</strong> wildcards.</aside>
-  </section>
-
-  <section class="bcls-section">
-    <h2 id="Stemming">Stemming</h2>
-
-    <p>Stemming is supported, but <strong>not</strong> partial word searches. For example, <code>q=name:ban</code> should return videos with the names "<code>Parking Ban Announced</code>" or "<code>Parking to be Banned</code>" or "<code>City Banning Parking</code>" but not "<code>Bank Holiday</code>" or "<code>Bandit Captured</code>".</p>
-  </section>
-
-  <h2 id="otherParams">Combined with other params</h2>
-
-  <p>Search can be combined with other parameters such a <code>sort</code>, <code>limit</code> and <code>offset</code>. All URL parameters are separated by <code>&amp;</code>, and the order does not matter.</p>
-
-  <aside class="bcls-aside bcls-aside--warning">Search param <code>limit</code> has a maximum value of <strong>100</strong> per request.  Please see <a href="https://support.brightcove.com/using-cms-api-page-search-results">Page Search Results</a> regarding video pagination.</aside>
-
-  <h3>Examples</h3>
-
-  <pre class="line-numbers"><code class="language-http">.../videos?q=name:foo%2Btags:bar&amp;sort=updated_at</code></pre>
-
-  In this example, returned videos must have a <code>tag</code> with value <code>"bar"</code> and may have a <code>name</code> containing <code>"foo"</code>
-
-  <pre class="line-numbers"><code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%2Btags:bar&amp;limit=10</code></pre>
-
-  This example used the same query as the example above, but additionally limits the results to just 10 videos and sorts those results by the field <code>updated_at</code>.
-
-  <section class="bcls-section">
-    <h2 id="specificVideos">Search specific videos</h2>
-
-    <p>If you want to limit your search to a specific set of videos, you can do so searching on <code>id</code>:</p>
-
-    <pre class="line-numbers"><code class="language-http">q=id:123456789+id:987654321+id:48376387</code></pre>
-
-    This example will return videos with ids <code>123456789</code>, <code>987654321</code> and <code>48376387</code>
-  </section>
-
-  <section class="bcls-section">
-    <h2 id="Ignored_words">Ignored words</h2>
-
-    <p>Certain words are ignored in search strings because they are so common that they are likely to return many results unrelated to what you are actually searching for. Below is a list of words that are ignored by search:</p>
-
-    <p>"a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these", "they", "this", "to", "was", "will", "with"</p>
-  </section>
-
+  <!-- Basic Search -->
   <section class="bcls-section">
     <h2 id="Basic_search">Basic search</h2>
 
     <p>To perform a search of terms in your media library, use the <code>q</code> parameter.</p>
 
-    <pre class="line-numbers">
-<code class="language-http">q={search terms}
-</code>
-</pre>
+    <pre class="line-numbers"><code class="language-http">q={search terms}</code></pre>
 
     <p>The search terms that you specify should be a url encoded list of terms separated by a space.</p>
 
@@ -192,15 +90,14 @@
     <div class="bcls-footnote" id="note1-1"><sup><strong>[1-1]</strong></sup> Note: searching by id is included for consistency, but a search on <code>q=id:12345</code> will return exactly the same results as the request <code>https://cms.api.brightcove.com/v1/accounts/{account_id}/videos/12345</code></div>
 
     <div class="bcls-footnote" id="note1-2"><sup><strong>[1-2]</strong></sup> If you have a list-type custom field and want to return videos that have one of several values, you can do so like this:
-
       <p>Let's say you have a field called <code>color</code> that can take the values: <code>red</code>, <code>green</code>, <code>yellow</code>, or <code>blue</code>. You want to find videos that have that field set to the value <code>green</code> or <code>blue</code>:</p>
 
-<pre> <code class="language-http">q=color:green+color:blue</code></pre>
+      <pre> <code class="language-http">q=color:green%20color:blue</code></pre>
     </div>
 
     <p>Example: This request returns videos which have a value of <code>bird</code> in at least one of the fields listed above.</p>
 
-<pre class="line-numbers"> <code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=bird </code></pre>
+    <pre class="line-numbers"> <code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=bird </code></pre>
 
     <aside class="bcls-aside bcls-aside--warning">Search strings of less than 3 characters will not work - instead, all videos will be returned.</aside>
 
@@ -210,67 +107,67 @@
 
     <p>Example: This request returns videos which have a value of <code>wildlife</code> in the <code>name</code> field.</p>
 
-<pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=name:wildlife</code></pre>
+    <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=name:wildlife</code></pre>
 
     <p>The supported search fields are:</p>
 
     <table class="bcls-table" id="supported_search_fields">
       <caption class="bcls-caption--table">Supported Search Fields</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>Field</th>
-          <th>Legal values</th>
-        </tr>
+      <tr>
+        <th>Field</th>
+        <th>Legal values</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td><code>name</code></td>
-          <td>strings or quoted strings</td>
-        </tr>
-        <tr>
-          <td>text</td>
-          <td>strings or quoted strings (searches the <code>name</code>, <code>description</code>, and <code>long_description</code>)</td>
-        </tr>
-        <tr>
-          <td><code>tags</code></td>
-          <td>strings or quoted strings (multiple tags should be comma-delimited)</td>
-        </tr>
-        <tr>
-          <td><code>custom_fields</code></td>
-          <td>strings or quoted strings (searches all custom fields - you can also use a specific custom field <em>internal</em> name) <sup><strong><a href="#note2-1">[2-1]</a> </strong></sup></td>
-        </tr>
-        <tr>
-          <td><code>reference_id</code></td>
-          <td>string or quoted string</td>
-        </tr>
-        <tr>
-          <td><code>state</code></td>
-          <td><code>ACTIVE</code>, <code>INACTIVE</code>, <code>PENDING</code>, <code>DELETED</code> <sup><strong><a href="#note2-3">[2-3]</a> </strong></sup></td>
-        </tr>
-        <tr>
-          <td><code>updated_at</code></td>
-          <td>date range</td>
-        </tr>
-        <tr>
-          <td><code>created_at</code></td>
-          <td>date range</td>
-        </tr>
-        <tr>
-          <td><code>schedule.starts_at</code></td>
-          <td>date range</td>
-        </tr>
-        <tr>
-          <td><code>schedule.ends_at</code></td>
-          <td>date range</td>
-        </tr>
-        <tr>
-          <td><code>published_at</code></td>
-          <td>date range</td>
-        </tr>
-        <tr>
-          <td><code>complete</code> <sup><strong><a href="#note2-2">[2-2]</a> </strong></sup></td>
-          <td><code>true</code> or <code>false</code></td>
-        </tr>
+      <tr>
+        <td><code>name</code></td>
+        <td>strings or quoted strings</td>
+      </tr>
+      <tr>
+        <td>text</td>
+        <td>strings or quoted strings (searches the <code>name</code>, <code>description</code>, and <code>long_description</code>)</td>
+      </tr>
+      <tr>
+        <td><code>tags</code></td>
+        <td>strings or quoted strings (multiple tags should be comma-delimited)</td>
+      </tr>
+      <tr>
+        <td><code>custom_fields</code></td>
+        <td>strings or quoted strings (searches all custom fields - you can also use a specific custom field <em>internal</em> name) <sup><strong><a href="#note2-1">[2-1]</a> </strong></sup></td>
+      </tr>
+      <tr>
+        <td><code>reference_id</code></td>
+        <td>string or quoted string</td>
+      </tr>
+      <tr>
+        <td><code>state</code></td>
+        <td><code>ACTIVE</code>, <code>INACTIVE</code>, <code>PENDING</code>, <code>DELETED</code> <sup><strong><a href="#note2-3">[2-3]</a> </strong></sup></td>
+      </tr>
+      <tr>
+        <td><code>updated_at</code></td>
+        <td>date range</td>
+      </tr>
+      <tr>
+        <td><code>created_at</code></td>
+        <td>date range</td>
+      </tr>
+      <tr>
+        <td><code>schedule.starts_at</code></td>
+        <td>date range</td>
+      </tr>
+      <tr>
+        <td><code>schedule.ends_at</code></td>
+        <td>date range</td>
+      </tr>
+      <tr>
+        <td><code>published_at</code></td>
+        <td>date range</td>
+      </tr>
+      <tr>
+        <td><code>complete</code> <sup><strong><a href="#note2-2">[2-2]</a> </strong></sup></td>
+        <td><code>true</code> or <code>false</code></td>
+      </tr>
       </tbody>
     </table>
 
@@ -292,53 +189,74 @@
     <aside class="bcls-aside bcls-aside--information">The fields that use a string value perform a text search against that field.</aside>
   </section>
 
+  <!-- Required/Excluded Search -->
   <section class="bcls-section">
     <h2 id="required_excluded_terms">Required/excluded terms</h2>
 
     <p>You can mark a search term as required (returned videos MUST match) or excluded (returned videos must NOT match). This is controlled with a URI-encoded <code>+ (%2B)</code> or <code>-</code> sign immediately preceding the term.</p>
 
-    <p>Note that because of the potential confusion between "+" as an indicator of a space or a required term, you must encode it as <code>%2B</code> when using it to indicate a required term.</p>
+    <p>You must encode <code>+</code> it as <code>%2B</code> when using it to indicate a required term.</p>
 
     <table class="bcls-table">
       <caption class="bcls-caption--table">Required/Excluded Terms</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>example</th>
-          <th>url-encoded</th>
-          <th>meaning</th>
-        </tr>
+      <tr>
+        <th>example</th>
+        <th>url-encoded</th>
+        <th>meaning</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td><code>+foo</code></td>
-          <td><code>%2Bfoo</code></td>
-          <td>videos MUST include the term <code>foo</code> in the <code>name</code>, <code>description</code>, <code>long_description</code>, <code>tags</code>, <code>reference_id</code> or <code>custom_fields</code></td>
-        </tr>
-        <tr>
-          <td><code>+custom_fields:foo</code></td>
-          <td><code>%2Bcustom_fields:foo</code></td>
-          <td>video MUST include the value <code>foo</code> for some custom field</td>
-        </tr>
-        <tr>
-          <td><code>-foo</code></td>
-          <td><code>-foo</code></td>
-          <td>videos must NOT include the term <code>foo</code> in the name, <code>description</code>, <code>long_description</code>, <code>tags</code>, <code>reference_id</code> or <code>custom_fields</code></td>
-        </tr>
-        <tr>
-          <td><code>-name:foo</code></td>
-          <td><code>-name:foo</code></td>
-          <td>videos must NOT include the term <code>foo</code> in the <code>name</code></td>
-        </tr>
+      <tr>
+        <td><code>+foo</code></td>
+        <td><code>%2Bfoo</code></td>
+        <td>videos MUST include the term <code>foo</code> in the <code>name</code>, <code>description</code>, <code>long_description</code>, <code>tags</code>, <code>reference_id</code> or <code>custom_fields</code></td>
+      </tr>
+      <tr>
+        <td><code>+custom_fields:foo</code></td>
+        <td><code>%2Bcustom_fields:foo</code></td>
+        <td>video MUST include the value <code>foo</code> for some custom field</td>
+      </tr>
+      <tr>
+        <td><code>+foo -bar</code></td>
+        <td><code>%2Bfoo%20-bar</code></td>
+        <td>videos MUST include the term <code>foo</code> but must NOT include the term <code>bar</code> in the <code>name</code>, <code>description</code>, <code>long_description</code>, <code>tags</code>, <code>reference_id</code> or <code>custom_fields</code></td>
+      </tr>
+      <tr>
+        <td><code>+name:foo -name:bar</code></td>
+        <td><code>%2Bname:foo%20-name:bar</code></td>
+        <td>videos MUST include the term <code>foo</code> but must NOT include the term <code>bar</code> in the <code>name</code></td>
+      </tr>
       </tbody>
     </table>
 
-    <p>Example: This request returns videos which DO NOT have a value of <code>sea</code> in the <code>tags</code> field.</p>
+    <p>Example: This request returns videos which HAVE a value of <code>sea</code> but DO NOT have a value of <code>lake</code> in the <code>tags</code> field.</p>
 
-<pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=-tags:sea</code></pre>
+    <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=%2Btags:sea%20-tags:lake</code></pre>
 
     <p>See <a href="#combine_search_criteria">Combining search criteria</a> below to see how to use required/excluded syntax to enforce AND logic for multiple search terms.</p>
   </section>
 
+  <!-- Combine search with other params -->
+  <section class="bcls-section">
+    <h2 id="otherParams">Combined with other params</h2>
+
+    <p>Search (using the <code>q</code> parameter) can be combined with other parameters such a <code>sort</code>, <code>limit</code> and <code>offset</code>. All URL parameters are separated by <code>&amp;</code>.  Parameter order does not matter.</p>
+
+    <aside class="bcls-aside bcls-aside--warning">Search param <code>limit</code> has a maximum value of <strong>100</strong> per request.  Please see <a href="https://support.brightcove.com/using-cms-api-page-search-results">Page Search Results</a> regarding video pagination.</aside>
+
+    <h3>Examples</h3>
+
+    <p>Example: This request returns videos which must have a value of <code>bar</code> in the <code>tag</code> field and may have a <code>name</code> containing value <code>foo</code></p>
+
+    <pre class="line-numbers"><code class="language-http">.../videos?q=name:foo%2Btags:bar&amp;sort=updated_at</code></pre>
+
+    <p>Example: This request returns the same videos as above, but additionally sorts those results by the field <code>updated_at</code> and then limits the results to just 10 videos.
+
+    <pre class="line-numbers"><code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%2Btags:bar&amp;limit=10</code></pre>
+  </section>
+
+  <!-- Quoted Search Terms -->
   <section class="bcls-section">
     <h2 id="Quoted_search_terms">Quoted search terms</h2>
 
@@ -347,44 +265,56 @@
     <p>Most browsers and other agents will treat literal quotation marks (<code>"..."</code>) correctly, but if you run into a case where quoted search terms do not appear to be returning correct results, try replacing the quotation marks with <code>%22</code>
       (<code>%22...%22</code>)</p>
 
-<pre class="line-numbers"><code class="language-http">q="foo" or q=%22foo%22
-q="foo+bar"or q=%22foo+bar%2</code>
-</pre>
+    <pre class="line-numbers">
+      <code class="language-http">
+        q="foo" or q=%22foo%22
+        q="foo%20bar" or q=%22foo%20bar%22
+      </code>
+    </pre>
 
     <aside class="bcls-aside bcls-aside--information">Note that the quotations marks require matching videos to have all the terms inside them, but not necessarily exact matches on those terms. For example, a search on <code>"home run"</code> might return a video with the words <code>homeless</code> and <code>running</code> in the title.</aside>
 
     <p>This also works when searching against a specific field:</p>
 
-<pre class="line-numbers"><code class="language-http">q=name:"home" q=name:"home+run" </code></pre>
+    <pre class="line-numbers">
+      <code class="language-http">
+        q=name:"home"
+        q=name:"home%20run"
+      </code>
+    </pre>
 
     <h3>Multiple words</h3>
 
     <p>Example: Notice that this request returns videos which have either a value of <code>sea</code> or <code>mammal</code> in the <code>tags</code> field.</p>
 
-<pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=tags:sea,mammal</code></pre>
+    <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=tags:sea,mammal</code></pre>
 
     <p>But, the following request returns only those videos which have a tag <code>sea,mammal</code>.</p>
 
-<pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=tags:"sea,mammal"</code></pre>
+    <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=tags:"sea,mammal"</code></pre>
 
-    <aside class="bcls-aside bcls-aside--warning">Tags are a special case where you can search for multiple tags as a comma-delimited list - that is not true for other fields like name, description, etc. For other kinds of multiple terms, combine terms with <code>+</code> sign, like this: <code>q=tags:"bird"+name:"owl"</code>.</aside>
+    <aside class="bcls-aside bcls-aside--warning">Tags are a special case where you can search for multiple tags as a comma-delimited list - that is not true for other fields like name, description, etc. For other kinds of multiple terms, combine terms with <code>+</code> sign, like this: <code>q=tags:"bird"%20name:"owl"</code>.</aside>
   </section>
 
+  <!-- Custom Field Search -->
   <section class="bcls-section">
     <h2 id="custom_fields">Custom fields</h2>
 
     <p>You may search on any custom field that you have defined for your videos.</p>
 
-<pre class="line-numbers"><code class="language-http">q=my_field:foo
+    <pre class="line-numbers"><code class="language-http">q=my_field:foo
 q=my_field:"foo"</code></pre>
 
     <p class="BCL-aside">Note: all custom field values are treated as strings. For example, if you have a list-type custom field that can take the values <code>true</code> or <code>false</code>, search will look for those strings, not boolean values (in many programming languages, <code>1</code> and <code>0</code> can be used interchangeably with <code>true</code> and <code>false</code> as boolean values, but searching on <code>q=my_boolean_field:1</code> will not return videos that have <code>my_boolean_field</code> set to <code>true</code>).</p>
 
     <p>Example: This request returns videos which have a value of <strong>animal</strong> in the <code>subject</code> custom field.</p>
 
-<pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=subject:animal</code></pre>
+    <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=subject:animal</code></pre>
   </section>
 
+
+  <!-- ***** -->
+  <!-- Date Search -->
   <section class="bcls-section">
     <h2 id="date_ranges">Date ranges</h2>
 
@@ -392,7 +322,7 @@ q=my_field:"foo"</code></pre>
 
     <p>This will search for all videos with an <code>updated_at</code> value between Aug 1, 2012 and October 8, 2012. Here we are specifying each date in UTC format.</p>
 
-<pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T00:00:00Z</code></pre>
+    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T00:00:00Z</code></pre>
 
     <h3>Supported date formats</h3>
 
@@ -401,24 +331,24 @@ q=my_field:"foo"</code></pre>
     <table class="bcls-table">
       <caption class="bcls-caption--table">Date Format Examples</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>format (URI-encoded format)</th>
-          <th>meaning</th>
-        </tr>
+      <tr>
+        <th>format (URI-encoded format)</th>
+        <th>meaning</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td>2015-08-01T06:15:00Z</td>
-          <td>This represents a time in UTC.</td>
-        </tr>
-        <tr>
-          <td>2012-08-01</td>
-          <td>This represents midnight on a day in UTC. The example is equivalent to 2012-08-01T00:00:00Z</td>
-        </tr>
-        <tr>
-          <td>-1d (-1d)</td>
-          <td>The current time minus 1 day. (see <a href="#relativeDates">below</a>)</td>
-        </tr>
+      <tr>
+        <td>2015-08-01T06:15:00Z</td>
+        <td>This represents a time in UTC.</td>
+      </tr>
+      <tr>
+        <td>2012-08-01</td>
+        <td>This represents midnight on a day in UTC. The example is equivalent to 2012-08-01T00:00:00Z</td>
+      </tr>
+      <tr>
+        <td>-1d (-1d)</td>
+        <td>The current time minus 1 day. (see <a href="#relativeDates">below</a>)</td>
+      </tr>
       </tbody>
     </table>
 
@@ -433,43 +363,36 @@ q=my_field:"foo"</code></pre>
     <table class="bcls-table">
       <caption class="bcls-caption--table">Relative Date Samples</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>q param for dates</th>
-          <th>URI-encoded</th>
-          <th>Meaning</th>
-        </tr>
+      <tr>
+        <th>q param for dates</th>
+        <th>Meaning</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td>q=updated_at:-1day..NOW</td>
-          <td>q=updated_at:-1day..NOW</td>
-          <td>videos updated from 1 day ago to the current day</td>
-        </tr>
-        <tr>
-          <td>q=created_at:-2days</td>
-          <td>q=created_at:-2days</td>
-          <td>videos added 2 days ago</td>
-        </tr>
-        <tr>
-          <td>q=updated_at:-4hours..NOW</td>
-          <td>q=updated_at:-4hours..NOW</td>
-          <td>video updated from 4 hours ago to the current time</td>
-        </tr>
-        <tr>
-          <td>q=created_at:-60minutes..</td>
-          <td>q=created_at:-60minutes..</td>
-          <td>videos added from 60 minutes ago to the current time</td>
-        </tr>
-        <tr>
-          <td>q=created_at:2016-01-01..-1d</td>
-          <td>q=created_at:2016-01-01..-1d</td>
-          <td>videos created from January 1, 2015 to one day ago</td>
-        </tr>
-        <tr>
-          <td>q=updated_at:-14d..NOW</td>
-          <td>q=updated_at:-14d..NOW</td>
-          <td>videos in the past two weeks</td>
-        </tr>
+      <tr>
+        <td>q=updated_at:-1day..NOW</td>
+        <td>videos updated from 1 day ago to the current day</td>
+      </tr>
+      <tr>
+        <td>q=created_at:-2days</td>
+        <td>videos added 2 days ago</td>
+      </tr>
+      <tr>
+        <td>q=updated_at:-4hours..NOW</td>
+        <td>video updated from 4 hours ago to the current time</td>
+      </tr>
+      <tr>
+        <td>q=created_at:-60minutes..</td>
+        <td>videos added from 60 minutes ago to the current time</td>
+      </tr>
+      <tr>
+        <td>q=created_at:2016-01-01..-1d</td>
+        <td>videos created from January 1, 2015 to one day ago</td>
+      </tr>
+      <tr>
+        <td>q=updated_at:-14d..NOW</td>
+        <td>videos in the past two weeks</td>
+      </tr>
       </tbody>
     </table>
 
@@ -484,7 +407,7 @@ q=my_field:"foo"</code></pre>
 </code>
 </pre>
 
-    <p>Example: Search for all videos modified after August 11, 2013:</p>
+    <p>Example: Search for all videos modified on or after August 11, 2013:</p>
 
     <pre class="line-numbers">
 <code class="language-http">q=updated_at:2013-08-11T00:00:00Z..
@@ -493,84 +416,43 @@ q=my_field:"foo"</code></pre>
 
     <h3><code>NOW</code> operator for schedule dates</h3>
 
-    <p>For <code>schedule.starts_at</code> and <code>schedule.ends_at</code>, you can use <code>NOW</code> as a date value. This is a convenience operator that allows you to set up a dynamic query based on the current date-time. By using the exclude option (-), you can also search for videos that have no explicit schedule set. A couple of examples:</p>
+    <p>For <code>schedule.starts_at</code> and <code>schedule.ends_at</code>, you can use <code>NOW</code> as a date value. This is a convenience operator that allows you to set up a dynamic query based on the current date-time.  A couple of examples:</p>
 
     <table class="bcls-table">
       <caption class="bcls-caption--table">Schedule Data Examples</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>from/to params</th>
-          <th>URI-encoded</th>
-          <th>Meaning</th>
-        </tr>
+      <tr>
+        <th>from/to params</th>
+        <th>URI-encoded</th>
+        <th>Meaning</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td>?q=schedule.starts_at:..NOW</td>
-          <td>?q=schedule.starts_at:..NOW</td>
-          <td>starts_at is from the beginning of time to this moment</td>
-        </tr>
-        <tr>
-          <td>?q=schedule.starts_at:NOW</td>
-          <td>?q=schedule.starts_at:NOW</td>
-          <td>starts_at is from this moment onward</td>
-        </tr>
-        <tr>
-          <td>?q=schedule.ends_at:NOW..</td>
-          <td>?q=schedule.ends_at:NOW..</td>
-          <td>ends_at is from this moment to the end of time</td>
-        </tr>
-        <tr>
-          <td>?q=-schedule.starts_at:NOW..</td>
-          <td>?q=-schedule.starts_at:NOW..</td>
-          <td>starts_at is NOT between this moment and the end of time (equivalent to starts_at is before this moment)</td>
-        </tr>
-        <tr>
-          <td>?q=-schedule.ends_at:NOW..</td>
-          <td>?q=-schedule.ends_at:NOW..</td>
-          <td>schedule ends at some time earlier than the present moment</td>
-        </tr>
-        <tr>
-          <td>?q=+schedule.starts_at:..NOW +schedule.ends_at:NOW..</td>
-          <td>?q=%2Bschedule.starts_at:..NOW+%2Bschedule.ends_at:NOW..</td>
-          <td>starts_at before this moment and ends_at after this moment (video is in schedule this moment)</td>
-        </tr>
-        <tr>
-          <td>?q=-schedule.starts_at:..NOW -schedule.ends_at:NOW..</td>
-          <td>?q=-schedule.starts_at:..NOW+-schedule.ends_at:NOW..</td>
-          <td>Excludes video if starts_at before this moment and ends_at after this moment (this returns videos with no schedule set)</td>
-        </tr>
+      <tr>
+        <td>?q=schedule.starts_at:..NOW</td>
+        <td>?q=schedule.starts_at:..NOW</td>
+        <td>starts_at is from the beginning of time to this moment</td>
+      </tr>
+      <tr>
+        <td>?q=schedule.starts_at:NOW</td>
+        <td>?q=schedule.starts_at:NOW</td>
+        <td>starts_at is from this moment onward</td>
+      </tr>
+      <tr>
+        <td>?q=schedule.ends_at:NOW..</td>
+        <td>?q=schedule.ends_at:NOW..</td>
+        <td>ends_at is from this moment to the end of time</td>
+      </tr>
+      <tr>
+        <td>?q=+schedule.starts_at:..NOW +schedule.ends_at:NOW..</td>
+        <td>?q=%2Bschedule.starts_at:..NOW%20%2Bschedule.ends_at:NOW..</td>
+        <td>starts_at before this moment and ends_at after this moment (video is in schedule this moment)</td>
+      </tr>
       </tbody>
     </table>
   </section>
 
-  <section class="bcls-section">
-    <h2 id="searchByState">Search by state</h2>
-
-    <p>You can perform or filter searches by the state of the video using the parameter:</p>
-
-<pre class="line-numbers"><code class="language-http">q=state:ACTIVE( | INACTIVE | PENDING | DELETED)<sup><strong><a href="#note3">[3]</a></strong></sup></code></pre>
-
-    <h3>Notes</h3>
-
-    <ul>
-      <li id="note3"><sup><strong>[3]</strong></sup> Search for DELETED videos is only available for videos deleted in the past 10 days (the current time minus 10 days), and only through the CMS API (not the Playback API).</li>
-    </ul>
-  </section>
-
-  <section class="bcls-section">
-    <h2 id="clips">Clip search terms</h2>
-
-    <p>Clips are videos created from sections of other videos. Clips can be generated by <a href="/node/16672">Brightcove Social</a>, and other means will be available in the future. There are some special search terms you can use to find generated clips in an account:</p>
-
-    <ul>
-      <li><code>q=%2Bis_clip:true</code> - returns only clips</li>
-      <li><code>q=-is_clip:true</code> - returns only non-clips</li>
-      <li><code>q=%2Bis_clip:false</code> - returns only non-clips (functionally identical to the previous item)</li>
-      <li><code>q=%2Bclip_source_video_id: <span class="bcls-input">video_id</span></code> - returns clips generated from the specified video</li>
-    </ul>
-  </section>
-
+  <!-- Combined Search -->
   <section class="bcls-section">
     <h2 id="combine_search_criteria">Combine search criteria</h2>
 
@@ -578,7 +460,7 @@ q=my_field:"foo"</code></pre>
 
     <p>Example: This request searches for videos with a <code>name</code> value of <strong>gossip</strong>, which were updated between August 1, 2010 and October 8, 2010. It then sorts the response data by <code>updated_at</code> date in descending order.</p>
 
-<pre class="line-numbers"><code class="language-http">q=%2Bname:gossip+%2Bupdated_at:2010-08-01T00:00:00Z..2010-10-08T00:00:00Z&amp;sort=-updated_at</code></pre>
+    <pre class="line-numbers"><code class="language-http">q=%2Bname:gossip%20%2Bupdated_at:2010-08-01..2010-10-08&amp;sort=-updated_at</code></pre>
 
     <h3>Combining terms</h3>
 
@@ -588,79 +470,199 @@ q=my_field:"foo"</code></pre>
 
     <p>For example, if you search on:</p>
 
-<pre class="line-numbers"><code class="language-http">q=name:foo+tags:bar (URI-encoded: q=name:foo%2Btags:bar)</code></pre>
+    <pre class="line-numbers"><code class="language-http">q=name:foo +tags:bar (URI-encoded: q=name:foo%20%2Btags:bar)</code></pre>
 
     <p>the response will contain videos that have the tag 'bar' and may also have <code>foo</code> in the name. If you want to return only those videos that have <code>foo</code> in the name AND the tag 'bar', you must search on:</p>
 
-<pre class="line-numbers"><code class="language-http">(unencoded) q=<strong>+</strong>name:foo <strong>+</strong>tags:bar (URI-encoded) q=<strong>%2B</strong>name:foo+<strong>%2B</strong>tags:bar</code></pre>
-
-    <aside class="bcls-aside bcls-aside--information">Notice the two versions of the <code>+</code> sign used in this sample. The literal <code>+</code> sign is interpreted by the CMS API as a replacement for a space - you could also use <code>%20</code> for that purpose. The URI-encoded plus sign ( <code>%2B</code> is interpreted as an indicator for a required match on the term - the returned videos must have "foo" in the name and the tag "bar").</aside>
+    <pre class="line-numbers"><code class="language-http">(unencoded) q=<strong>+</strong>name:foo <strong>+</strong>tags:bar (URI-encoded) q=<strong>%2B</strong>name:foo%20<strong>%2B</strong>tags:bar</code></pre>
 
     <p>Similarly, if you want to return only videos that have <code>foo</code> in the name, but do <strong>not</strong> have the tag 'bar', you would search on:</p>
 
-<pre class="line-numbers"><code class="language-http">(unencoded) q=<strong>+</strong>name:foo<strong> -</strong>tags:bar (encoded) q=<strong>%2B</strong>name:foo+<strong>-</strong>tags:bar</code></pre>
+    <pre class="line-numbers"><code class="language-http">(unencoded) q=<strong>+</strong>name:foo<strong> -</strong>tags:bar (encoded) q=<strong>%2B</strong>name:foo%20<strong>-</strong>tags:bar</code></pre>
 
     <h4>Examples</h4>
 
     <table class="bcls-table">
       <caption class="bcls-caption--table">Samples: Combining Terms</caption>
       <thead class="bcls-table__head">
-        <tr>
-          <th>Unencoded search string</th>
-          <th>URI-encoded search string</th>
-          <th>Meaning</th>
-        </tr>
+      <tr>
+        <th>Unencoded search string</th>
+        <th>URI-encoded search string</th>
+        <th>Meaning</th>
+      </tr>
       </thead>
       <tbody class="bcls-table__body">
-        <tr>
-          <td><code>q=foo bar</code></td>
-          <td><code>q=foo+bar</code></td>
-          <td>returned items have "foo" OR "bar"</td>
-        </tr>
-        <tr>
-          <td><code>q=foo +bar</code></td>
-          <td><code>q=foo+%2Bbar</code></td>
-          <td>returned items must have "bar", may have "foo"</td>
-        </tr>
-        <tr>
-          <td><code>q=+foo bar</code></td>
-          <td>q <code>=%2Bfoo+bar</code></td>
-          <td>returned items must have "foo", may have "bar"</td>
-        </tr>
-        <tr>
-          <td><code>q=+foo +bar</code></td>
-          <td><code>q=%2Bfooc+%2Bbar</code></td>
-          <td>returned item must have "foo" AND "bar"</td>
-        </tr>
-        <tr>
-          <td><code>q=-foo +bar</code></td>
-          <td><code>q=-foo+%2Bbar</code></td>
-          <td>returned item must have "bar" AND not have "foo"</td>
-        </tr>
-        <tr>
-          <th colspan="3">Multiple tag searches</th>
-        </tr>
-        <tr>
-          <td><code>q=tags:bee,bop</code></td>
-          <td><code>q=tags:bee,bop</code></td>
-          <td>returns videos with tag "bee" OR "bop"</td>
-        </tr>
-        <tr>
-          <td><code>q=tags:bee+tags:bop</code></td>
-          <td><code>q=tags:bee+tags:bop</code></td>
-          <td>returns videos with tag "bee" OR "bop"</td>
-        </tr>
-        <tr>
-          <td><code>q=+tags:bee+tags:bop</code></td>
-          <td><code>q=%2Btags:bee+tags:bop</code></td>
-          <td>all videos returned must have tag "bee"; they may have tag "bop" as well</td>
-        </tr>
-        <tr>
-          <td><code>q=+tags:bee++tags:bop</code></td>
-          <td><code>q=%2Btags:bee+%2Btags:bop</code></td>
-          <td>all videos returned will have tag "bee" AND tag "bop"</td>
-        </tr>
+      <tr>
+        <td><code>q=foo bar</code></td>
+        <td><code>q=foo%20bar</code></td>
+        <td>returned items have "foo" OR "bar"</td>
+      </tr>
+      <tr>
+        <td><code>q=foo +bar</code></td>
+        <td><code>q=foo%20%2Bbar</code></td>
+        <td>returned items must have "bar", may have "foo"</td>
+      </tr>
+      <tr>
+        <td><code>q=+foo bar</code></td>
+        <td>q <code>=%2Bfoo%20bar</code></td>
+        <td>returned items must have "foo", may have "bar"</td>
+      </tr>
+      <tr>
+        <td><code>q=+foo +bar</code></td>
+        <td><code>q=%2Bfooc%20%2Bbar</code></td>
+        <td>returned item must have "foo" AND "bar"</td>
+      </tr>
+      <tr>
+        <td><code>q=-foo +bar</code></td>
+        <td><code>q=-foo%20%2Bbar</code></td>
+        <td>returned item must have "bar" AND not have "foo"</td>
+      </tr>
+      <tr>
+        <th colspan="3">Multiple tag searches</th>
+      </tr>
+      <tr>
+        <td><code>q=tags:bee,bop</code></td>
+        <td><code>q=tags:bee,bop</code></td>
+        <td>returns videos with tag "bee" OR "bop"</td>
+      </tr>
+      <tr>
+        <td><code>q=tags:bee tags:bop</code></td>
+        <td><code>q=tags:bee%20tags:bop</code></td>
+        <td>returns videos with tag "bee" OR "bop"</td>
+      </tr>
+      <tr>
+        <td><code>q=+tags:bee tags:bop</code></td>
+        <td><code>q=%2Btags:bee%20tags:bop</code></td>
+        <td>all videos returned must have tag "bee"; they may have tag "bop" as well</td>
+      </tr>
+      <tr>
+        <td><code>q=+tags:bee +tags:bop</code></td>
+        <td><code>q=%2Btags:bee%20%2Btags:bop</code></td>
+        <td>all videos returned will have tag "bee" AND tag "bop"</td>
+      </tr>
       </tbody>
     </table>
   </section>
+
+  <!-- Search for specfic videos -->
+  <section class="bcls-section">
+    <h2 id="specificVideos">Search specific videos</h2>
+
+    <p>If you want to limit your search to a specific set of videos, you can do so searching on <code>id</code>:</p>
+
+    <p>Example: This request returns videos with ids <code>123456789</code>, <code>987654321</code> and <code>48376387</code>
+
+    <pre class="line-numbers"><code class="language-http">q=id:123456789%20id:987654321%20id:48376387</code></pre>
+  </section>
+
+  <!-- State Search -->
+  <section class="bcls-section">
+    <h2 id="searchByState">Search by state</h2>
+
+    <p>You can perform or filter searches by the state of the video using the parameter:</p>
+
+    <pre class="line-numbers"><code class="language-http">q=state:ACTIVE( | INACTIVE | PENDING | DELETED)<sup><strong><a href="#note3">[3]</a></strong></sup></code></pre>
+
+    <h3>Notes</h3>
+
+    <ul>
+      <li id="note3"><sup><strong>[3]</strong></sup> Search for DELETED videos is only available for videos deleted in the past 10 days (the current time minus 10 days), and only through the CMS API (not the Playback API).</li>
+    </ul>
+  </section>
+
+  <!-- Stemming -->
+  <section class="bcls-section">
+    <h2 id="Stemming">Stemming</h2>
+
+    <p>Stemming is supported, but <strong>not</strong> partial word searches. For example, <code>q=name:ban</code> should return videos with the names "<code>Parking Ban Announced</code>" or "<code>Parking to be Banned</code>" or "<code>City Banning Parking</code>" but not "<code>Bank Holiday</code>" or "<code>Bandit Captured</code>".</p>
+  </section>
+
+  <!-- Special Characters/Encoding -->
+  <section class="bcls-section">
+    <h2 id="url_encoding">Spaces/Special Characters</h2>
+
+    <p>The CMS API generally handles special characters in search strings, with a couple of exceptions:</p>
+
+    <ul>
+      <li>Spaces are not allowed, and can be replaced either with <code>%20</code>.
+
+        (<code>+</code> signs can also replace spaces, but this can lead to confusion in your queries as <code>+</code> can also indicate that a term is required.  See  <a href="#requiredexcludedterms">required/excluded syntax</a>)
+
+        <p>For example, to search for "my favorite video" in the name:</p>
+
+        <p><code>q=name:"my%20favorite%20video"</code></p>
+
+        <aside class="bcls-aside bcls-aside--information">Note that the quotation marks ensure that returned videos have all the terms. Without them, videos having any of the three terms would be returned. More on that below.</aside>
+      </li>
+      <li>To search for a literal <code>+</code> sign or to use the <code>+</code> to indicate that the returned videos <strong>must</strong> include a term, you must encode the <code>+</code> as <code>%2B</code>:
+
+        <p>Searching for Videos that must contain <code>"two+two"</code> in the name field</p>
+        <p><code>q=name:two%2Btwo</code></p>
+
+        <p>Searching for Videos that must contain <code>"heron"</code> in the name field</p>
+        <p><code>q=%2Bname:heron</code></p>
+      </li>
+      <li>Some agents may not handle literal quotation marks correctly, so it is safer to encode <code>"foo"</code> as <code>%22foo%22</code></li>
+    </ul>
+
+    <aside class="bcls-aside bcls-aside--information">Notes:
+      <p>For multi-word tags or strings, enclose the tag/string in URI-encoded quotation marks ( <code>%22</code>), and URI-encode the spaces <code>(%20)</code>:</p>
+
+      <table class="bcls-table">
+        <caption class="bcls-caption--table">Multi-Word Tag Example</caption>
+        <thead class="bcls-table__head">
+        <tr>
+          <th>Unencoded Search String</th>
+          <th>Encoded Search String</th>
+        </tr>
+        </thead>
+        <tbody class="bcls-table__body">
+        <tr>
+          <td><code>q=tags:"multi word tag"</code></td>
+          <td><code>q=tags:%22multi%20word%20tag%22</code></td>
+        </tr>
+        </tbody>
+      </table>
+
+      <p>The quotation marks ensure that videos returned will match ALL of the terms, but NOT necessarily the exact terms. <a href="#Stemming">Stemming</a> still applies - for example, a search on <code>"new house"</code> will also return videos with a <code>name</code> or <code>description</code> like <code>news about housing</code>.</p>
+    </aside>
+
+    <p>For one-off requests, you can use Brightcove Learning's <a href="/node/18290">string encoder</a> to encode your search strings. For apps, you'll need to find a URI encoding function in the language you are using.</p>
+
+    <aside class="bcls-aside bcls-aside--warning">Asterisks ( <strong>*</strong>) are treated as ordinary special characters, <strong>not</strong> wildcards.</aside>
+  </section>
+
+  <!-- Clip Search -->
+  <section class="bcls-section">
+    <h2 id="clips">Clip search terms</h2>
+
+    <p>Clips are videos created from sections of other videos. Clips can be generated by <a href="/node/16672">Brightcove Social</a>, and other means will be available in the future. There are some special search terms you can use to find generated clips in an account:</p>
+
+    <ul>
+      <li><code>q=%2Bis_clip:true</code> - returns only clips</li>
+      <li><code>q=%2Bis_clip:false</code> - returns only non-clips</li>
+      <li><code>q=%2Bclip_source_video_id: <span class="bcls-input">video_id</span></code> - returns clips generated from the specified video</li>
+    </ul>
+  </section>
+
+  <!-- Sorting results -->
+  <section class="bcls-section">
+    <h2 id="Sorting_of_search_results">Sorting of search results</h2>
+
+    <p>For search queries that return a large number of results, the sorting of the results is based on a complex relevance algorithm.</p>
+
+    <p>For example, let's say you search on the terms <code>coastal,city</code> and there are 120 videos in your account that have those terms somewhere in the video metadata ( <code>name</code>, <code>description</code>, <code>tags</code>, and so
+      forth) and that also match the sorting criteria for the results (for example, they all have the same <code>schedule_starts_at</code> date/time). How high in the results a video appears is determined by the frequency that one or both terms
+      appear in the metadata, with greater weight given to the term that appears most frequently in your video library as a whole.</p>
+  </section>
+
+  <!-- Ignored Words -->
+  <section class="bcls-section">
+    <h2 id="Ignored_words">Ignored words</h2>
+
+    <p>Certain words are ignored in search strings because they are so common that they are likely to return many results unrelated to what you are actually searching for. Below is a list of words that are ignored by search:</p>
+
+    <p>"a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these", "they", "this", "to", "was", "will", "with"</p>
+  </section>
+
 </article>

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -253,7 +253,7 @@
 
     <p>Example: This request returns the same videos as above, but additionally sorts those results by the field <code>updated_at</code> and then limits the results to just 10 videos.
 
-    <pre class="line-numbers"><code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%2Btags:bar&amp;limit=10</code></pre>
+    <pre class="line-numbers"><code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%20%2Btags:bar&amp;limit=10</code></pre>
   </section>
 
   <!-- Quoted Search Terms -->

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -194,7 +194,7 @@
   <section class="bcls-section">
     <h2 id="Sorting_of_search_results">Sorting of search results</h2>
 
-    <p>For search queries that return a large number of results, the sorting of the results is based on a complex relevance algorithm.</p>
+    <p>When not explicitly sorting results through the use of <code>sort</code>, results will be sorted according to an algorithm know as Term Frequency/Inverse Document Frequency or <code>TF-IDF</code>.  See <a href="https://en.wikipedia.org/wiki/Tf%E2%80%93idf">here</a> for more information.</p>
 
     <p>For example, let's say you search on the terms <code>coastal,city</code> and there are 120 videos in your account that have those terms somewhere in the video metadata ( <code>name</code>, <code>description</code>, <code>tags</code>, and so
       forth) and that also match the sorting criteria for the results (for example, they all have the same <code>schedule_starts_at</code> date/time). How high in the results a video appears is determined by the frequency that one or both terms
@@ -360,7 +360,7 @@ q=my_field:"foo"</code></pre>
         <td>This represents midnight on a day in UTC. The example is equivalent to 2012-08-01T00:00:00Z</td>
       </tr>
       <tr>
-        <td>-1d (-1d)</td>
+        <td>-1d</td>
         <td>The current time minus 1 day. (see <a href="#relativeDates">below</a>)</td>
       </tr>
       </tbody>

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -111,7 +111,7 @@
         </tbody>
       </table>
 
-      <p>The quotation marks insure that videos returned will match ALL of the terms, but NOT necessarily the exact terms. <a href="#Stemming">Stemming</a> still applies - for example, a search on <code>"new house"</code> will also return videos with a <code>name</code> or <code>description</code> like <code>news about housing</code>.</p>
+      <p>The quotation marks ensure that videos returned will match ALL of the terms, but NOT necessarily the exact terms. <a href="#Stemming">Stemming</a> still applies - for example, a search on <code>"new house"</code> will also return videos with a <code>name</code> or <code>description</code> like <code>news about housing</code>.</p>
     </aside>
 
     <p>For one-off requests, you can use Brightcove Learning's <a href="/node/18290">string encoder</a> to encode your search strings. For apps, you'll need to find a URI encoding function in the language you are using.</p>
@@ -129,27 +129,26 @@
 
   <p>Search can be combined with other parameters such a <code>sort</code>, <code>limit</code> and <code>offset</code>. All URL parameters are separated by <code>&amp;</code>, and the order does not matter.</p>
 
+  <aside class="bcls-aside bcls-aside--warning">Search param <code>limit</code> has a maximum value of <strong>100</strong> per request.  Please see <a href="https://support.brightcove.com/using-cms-api-page-search-results">Page Search Results</a> regarding video pagination.</aside>
+
   <h3>Examples</h3>
 
-  <pre class="line-numbers">
-<code class="language-http">.../videos?q=name:foo%2Btags:bar&amp;sort=updated_at
-</code>
-</pre>
+  <pre class="line-numbers"><code class="language-http">.../videos?q=name:foo%2Btags:bar&amp;sort=updated_at</code></pre>
 
-  <pre class="line-numbers">
-<code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%2Btags:bar&amp;limit=10
-</code>
-</pre>
+  In this example, returned videos must have a <code>tag</code> with value <code>"bar"</code> and may have a <code>name</code> containing <code>"foo"</code>
+
+  <pre class="line-numbers"><code class="language-http">.../videos?sort=updated_at&amp;q=name:foo%2Btags:bar&amp;limit=10</code></pre>
+
+  This example used the same query as the example above, but additionally limits the results to just 10 videos and sorts those results by the field <code>updated_at</code>.
 
   <section class="bcls-section">
     <h2 id="specificVideos">Search specific videos</h2>
 
     <p>If you want to limit your search to a specific set of videos, you can do so searching on <code>id</code>:</p>
 
-    <pre class="line-numbers">
-<code class="language-http">q=id:123456789+id:987654321+id:48376387
-</code>
-</pre>
+    <pre class="line-numbers"><code class="language-http">q=id:123456789+id:987654321+id:48376387</code></pre>
+
+    This example will return videos with ids <code>123456789</code>, <code>987654321</code> and <code>48376387</code>
   </section>
 
   <section class="bcls-section">

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -311,9 +311,7 @@ q=my_field:"foo"</code></pre>
 
     <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=subject:animal</code></pre>
   </section>
-
-
-  <!-- ***** -->
+  
   <!-- Date Search -->
   <section class="bcls-section">
     <h2 id="date_ranges">Date ranges</h2>

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -311,7 +311,7 @@ q=my_field:"foo"</code></pre>
 
     <pre class="line-numbers"><code class="language-http">https://cms.api.brightcove.com/v1/accounts/921483702001/videos?q=subject:animal</code></pre>
   </section>
-  
+
   <!-- Date Search -->
   <section class="bcls-section">
     <h2 id="date_ranges">Date ranges</h2>
@@ -320,7 +320,7 @@ q=my_field:"foo"</code></pre>
 
     <p>This will search for all videos with an <code>updated_at</code> value between Aug 1, 2012 and October 8, 2012. Here we are specifying each date in UTC format.</p>
 
-    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T00:00:00Z</code></pre>
+    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T23:59:99Z</code></pre>
 
     <h3>Supported date formats</h3>
 

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -507,7 +507,7 @@ q=my_field:"foo"</code></pre>
       </tr>
       <tr>
         <td><code>q=+foo +bar</code></td>
-        <td><code>q=%2Bfooc%20%2Bbar</code></td>
+        <td><code>q=%2Bfoo%20%2Bbar</code></td>
         <td>returned item must have "foo" AND "bar"</td>
       </tr>
       <tr>

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -582,7 +582,7 @@ q=my_field:"foo"</code></pre>
     <p>The CMS API generally handles special characters in search strings, with a couple of exceptions:</p>
 
     <ul>
-      <li>Spaces are not allowed, and can be replaced either with <code>%20</code>.
+      <li>Spaces are not allowed, and must be encoded as <code>%20</code>.
 
         (<code>+</code> signs can also replace spaces, but this can lead to confusion in your queries as <code>+</code> can also indicate that a term is required.  See  <a href="#requiredexcludedterms">required/excluded syntax</a>)
 

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -320,7 +320,11 @@ q=my_field:"foo"</code></pre>
 
     <p>This will search for all videos with an <code>updated_at</code> value between Aug 1, 2012 and October 8, 2012. Here we are specifying each date in UTC format.</p>
 
-    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T23:59:99Z</code></pre>
+    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01T00:00:00Z..2012-10-08T23:59:59Z</code></pre>
+
+    <p>You can simplify this search by dropping the time components.  The following is equivalent to the search above.</p>
+
+    <pre class="line-numbers"><code class="language-http">q=updated_at:2012-08-01..2012-10-08</code></pre>
 
     <h3>Supported date formats</h3>
 

--- a/doc-assets/node/18005-search-videos/18005.html
+++ b/doc-assets/node/18005-search-videos/18005.html
@@ -207,7 +207,7 @@
 
     <p>You can mark a search term as required (returned videos MUST match) or excluded (returned videos must NOT match). This is controlled with a URI-encoded <code>+ (%2B)</code> or <code>-</code> sign immediately preceding the term.</p>
 
-    <p>You must encode <code>+</code> it as <code>%2B</code> when using it to indicate a required term.</p>
+    <p>You must encode <code>+</code> as <code>%2B</code> when using it to indicate a required term.</p>
 
     <table class="bcls-table">
       <caption class="bcls-caption--table">Required/Excluded Terms</caption>
@@ -600,7 +600,7 @@ q=my_field:"foo"</code></pre>
     <ul>
       <li>Spaces are not allowed, and must be encoded as <code>%20</code>.
 
-        (<code>+</code> signs can also replace spaces, but this can lead to confusion in your queries as <code>+</code> can also indicate that a term is required.  See  <a href="#requiredexcludedterms">required/excluded syntax</a>)
+        (Unencoded <code>+</code> signs can also replace spaces, but this can lead to confusion in your queries as <code>+</code> can also indicate that a term is required.  See  <a href="#requiredexcludedterms">required/excluded syntax</a>)
 
         <p>For example, to search for "my favorite video" in the name:</p>
 


### PR DESCRIPTION
Reordered many sections of the page as they seemed very random.  For example, the current search doc page starts with an overview of CMS and Playback then oddly dives in to `Sorting` and the `Special Characters` before even reaching how to do a basic search.  

The intro lists these bullets which seemed logical to keep the page in this basic order...

```
Create and limit a basic search using the q parameter
Search using required and excluded terms
Use a quoted search to match exact terms and multiple words
Search on custom fields
Search date fields with a specific date and with ranges
Combine search criteria
```

Additionally: 

* Changed all the examples to use `%20` rather than `+` as a term delimiter.  There is now only a brief mention that `+` is an alternative to encoded space.  
* Also removed many exclusion (`-`) examples.  Exclusion examples now mainly focus on using `-` as a filter of a larger combined query rather than as a primary search element.  